### PR TITLE
chore: Add external wallets.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,18 +2,18 @@ GEM
   remote: https://rubygems.org/
   specs:
     concurrent-ruby (1.2.2)
-    cybrid_api_bank_ruby (0.67.0)
+    cybrid_api_bank_ruby (0.74.18)
       typhoeus (~> 1.0, >= 1.0.1)
     diff-lcs (1.5.0)
     dotenv (2.8.1)
     ethon (0.16.0)
       ffi (>= 1.15.0)
-    faraday (2.7.4)
+    faraday (2.7.7)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
     ffi (1.15.5)
-    i18n (1.12.0)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     money (6.16.0)
       i18n (>= 0.6.4, <= 2)
@@ -21,21 +21,22 @@ GEM
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
       rspec-mocks (~> 3.12.0)
-    rspec-core (3.12.1)
+    rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
-    rspec-expectations (3.12.2)
+    rspec-expectations (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.4)
+    rspec-mocks (3.12.5)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-support (3.12.0)
+    rspec-support (3.12.1)
     ruby2_keywords (0.0.5)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/app/auth.rb
+++ b/app/auth.rb
@@ -13,6 +13,7 @@ module Auth
   QUOTES_SCOPES = %w[quotes:read quotes:execute].freeze
   TRADES_SCOPES = %w[trades:read trades:execute].freeze
   TRANSFERS_SCOPES = %w[transfers:read transfers:execute].freeze
+  EXTERNAL_WALLET_SCOPES = %w[external_wallets:read external_wallets:execute].freeze
 
   SCOPES = [
     *ACCOUNTS_SCOPES,
@@ -21,7 +22,8 @@ module Auth
     *PRICES_SCOPES,
     *QUOTES_SCOPES,
     *TRADES_SCOPES,
-    *TRANSFERS_SCOPES
+    *TRANSFERS_SCOPES,
+    *EXTERNAL_WALLET_SCOPES
   ].freeze
 
   def self.token


### PR DESCRIPTION
We migrated from `OneTimeAddresses` to `ExternalWallets` so need to update our demo application.

All `Transfers` of type `crypto` need to now use `ExternalWallets` as the destination. `OneTimeAddresses` are no longer supported.