### PR TITLE
chore: Update to use bank fiat accounts.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     concurrent-ruby (1.2.2)
-    cybrid_api_bank_ruby (0.78.7)
+    cybrid_api_bank_ruby (0.81.0)
       typhoeus (~> 1.0, >= 1.0.1)
     diff-lcs (1.5.0)
     dotenv (2.8.1)

--- a/app/currency.rb
+++ b/app/currency.rb
@@ -71,7 +71,7 @@ usdc_ste = {
   name: 'USDC (STE)',
   symbol: '$',
   subunit: 'cents',
-  subunit_to_unit: 1_0_000_000,
+  subunit_to_unit: 10_000_000,
   separator: '.',
   delimiter: ','
 }


### PR DESCRIPTION
As of API version v0.81.0 banks no longer have backstopped accounts, but rather have fiat accounts just like customers.

These fiat accounts can be used to book transfer funds to/ from the bank to customers.

The script operated under the old model where banks had backstopped accounts and, thus, required an update to use the bank's fiat account.